### PR TITLE
Use correct file extension for file download

### DIFF
--- a/src/carcin/run_presenter.cr
+++ b/src/carcin/run_presenter.cr
@@ -27,7 +27,15 @@ module Carcin
       @created_at   = run.created_at
       @url          = "%s/runs/%s" % {Carcin::BASE_URL, @id}
       @html_url     = "%s/#/r/%s" % {Carcin::FRONTEND_URL, @id}
-      @download_url = "%s/runs/%s.cr" % {Carcin::BASE_URL, @id}
+      file_extension = case @language
+                       when "crystal"
+                         ".cr"
+                       when "ruby"
+                         ".rb"
+                       when "gcc"
+                         ".c"
+                       end
+      @download_url = "%s/runs/%s#{file_extension}" % {Carcin::BASE_URL, @id}
     end
   end
 end

--- a/src/carcin/run_presenter.cr
+++ b/src/carcin/run_presenter.cr
@@ -28,7 +28,7 @@ module Carcin
       @url          = "%s/runs/%s" % {Carcin::BASE_URL, @id}
       @html_url     = "%s/#/r/%s" % {Carcin::FRONTEND_URL, @id}
       file_extension = Carcin::Runner::RUNNERS[@language].short_name
-      @download_url = "%s/runs/%s%s" % {Carcin::BASE_URL, @id, file_extension}
+      @download_url = "%s/runs/%s.%s" % {Carcin::BASE_URL, @id, file_extension}
     end
   end
 end

--- a/src/carcin/run_presenter.cr
+++ b/src/carcin/run_presenter.cr
@@ -35,7 +35,7 @@ module Carcin
                        when "gcc"
                          ".c"
                        end
-      @download_url = "%s/runs/%s#{file_extension}" % {Carcin::BASE_URL, @id}
+      @download_url = "%s/runs/%s%s" % {Carcin::BASE_URL, @id, file_extension}
     end
   end
 end

--- a/src/carcin/run_presenter.cr
+++ b/src/carcin/run_presenter.cr
@@ -27,11 +27,7 @@ module Carcin
       @created_at   = run.created_at
       @url          = "%s/runs/%s" % {Carcin::BASE_URL, @id}
       @html_url     = "%s/#/r/%s" % {Carcin::FRONTEND_URL, @id}
-      file_extension = case @language
-                       when "crystal" then ".cr"
-                       when "ruby"    then ".rb"
-                       when "gcc"     then ".c"
-                       end
+      file_extension = Carcin::Runner::RUNNERS[@language].short_name
       @download_url = "%s/runs/%s%s" % {Carcin::BASE_URL, @id, file_extension}
     end
   end

--- a/src/carcin/run_presenter.cr
+++ b/src/carcin/run_presenter.cr
@@ -28,12 +28,9 @@ module Carcin
       @url          = "%s/runs/%s" % {Carcin::BASE_URL, @id}
       @html_url     = "%s/#/r/%s" % {Carcin::FRONTEND_URL, @id}
       file_extension = case @language
-                       when "crystal"
-                         ".cr"
-                       when "ruby"
-                         ".rb"
-                       when "gcc"
-                         ".c"
+                       when "crystal" then ".cr"
+                       when "ruby"    then ".rb"
+                       when "gcc"     then ".c"
                        end
       @download_url = "%s/runs/%s%s" % {Carcin::BASE_URL, @id, file_extension}
     end


### PR DESCRIPTION
Fixes #6 

Currently for GCC, Ruby and Crystal always the `.cr` file extension is used. This fixes it.